### PR TITLE
Resepect dark  mode preferences

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -132,7 +132,11 @@ function findThemeColor() {
 		RESPONSE_COLOR = "PLAINTEXT";
 		return true;
 	} else {
-		let headerTag = document.querySelector(`meta[name="theme-color"]`);
+		const colorScheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+		let headerTag = document.querySelector(`meta[name="theme-color"][media="(prefers-color-scheme: ${colorScheme})"]`);
+		if (typeof headerTag === "undefined") {
+			headerTag = document.querySelector(`meta[name="theme-color"]`);
+		}
 		if (headerTag != null) {
 			RESPONSE_COLOR = rgba(headerTag.content);
 			//Return true if it is legal and can be sent to background.js


### PR DESCRIPTION
First, search for `theme-color` tags with a matching `color-scheme` preference. If none found, search for any.