### PR TITLE
add: dynamic contrast-relative overlay opacity

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -63,6 +63,14 @@
 		"message": "Vorgegebene Theme-Farbe ignorieren"
 	},
 
+	"overlay": {
+		"message": "Overlay"
+	},
+
+	"opacityFactor": {
+		"message": "Opazitätsfaktor"
+	},
+
 	"tabBar": {
 		"message": "Tableiste"
 	},

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -71,6 +71,10 @@
 		"message": "Opazitätsfaktor"
 	},
 
+	"opacityThreshold": {
+		"message": "Opazitätsschwelle"
+	},
+
 	"tabBar": {
 		"message": "Tableiste"
 	},

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -63,6 +63,14 @@
 		"message": "Ignore designated theme colour"
 	},
 
+	"overlay": {
+		"message": "Overlay"
+	},
+
+	"opacityFactor": {
+		"message": "Opacity factor"
+	},
+
 	"tabBar": {
 		"message": "Tab bar"
 	},

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -71,6 +71,10 @@
 		"message": "Opacity factor"
 	},
 
+	"opacityThreshold": {
+		"message": "Opacity threshold"
+	},
+
 	"tabBar": {
 		"message": "Tab bar"
 	},

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -63,6 +63,14 @@
 		"message": "Ignore designated theme color"
 	},
 
+	"overlay": {
+		"message": "Overlay"
+	},
+
+	"opacityFactor": {
+		"message": "Opacity factor"
+	},
+
 	"tabBar": {
 		"message": "Tab bar"
 	},

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -71,6 +71,10 @@
 		"message": "Opacity factor"
 	},
 
+	"opacityThreshold": {
+		"message": "Opacity threshold"
+	},
+
 	"tabBar": {
 		"message": "Tab bar"
 	},

--- a/_locales/es_ES/messages.json
+++ b/_locales/es_ES/messages.json
@@ -71,6 +71,10 @@
 		"message": "Factor de opacidad"
 	},
 
+	"opacityThreshold": {
+		"message": "Umbral de opacidad"
+	},
+
 	"tabBar": {
 		"message": "Barra de pestañas"
 	},

--- a/_locales/es_ES/messages.json
+++ b/_locales/es_ES/messages.json
@@ -63,6 +63,14 @@
 		"message": "Ignora el thema de color designado"
 	},
 
+	"overlay": {
+		"message": "Superposición"
+	},
+
+	"opacityFactor": {
+		"message": "Factor de opacidad"
+	},
+
 	"tabBar": {
 		"message": "Barra de pestañas"
 	},

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -63,6 +63,14 @@
 		"message": "忽略網站指定的主題色"
 	},
 
+	"overlay": {
+		"message": "覆盖"
+	},
+
+	"opacityFactor": {
+		"message": "不透明度系数"
+	},
+
 	"tabBar": {
 		"message": "索引標籤列"
 	},

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -71,6 +71,10 @@
 		"message": "不透明度系数"
 	},
 
+	"opacityThreshold": {
+		"message": "不透明度閾值"
+	},
+
 	"tabBar": {
 		"message": "索引標籤列"
 	},

--- a/background.js
+++ b/background.js
@@ -15,6 +15,7 @@ var pref_allow_dark_light; // force
 var pref_dynamic; // dynamic
 var pref_no_theme_colour; // no_theme_color
 var pref_overlay_opacity_factor; // overlay_opacity_factor
+var pref_overlay_opacity_threshold; // overlay_opacity_threshold
 var pref_tabbar; // tabbar_color
 var pref_tab_selected; // tab_selected_color
 var pref_toolbar; // toolbar_color
@@ -50,6 +51,7 @@ function cachePref(pref) {
 	pref_dynamic = pref.dynamic;
 	pref_no_theme_colour = pref.no_theme_color;
 	pref_overlay_opacity_factor = pref.overlay_opacity_factor;
+	pref_overlay_opacity_threshold = pref.overlay_opacity_threshold;
 	pref_tabbar = pref.tabbar_color;
 	pref_tab_selected = pref.tab_selected_color;
 	pref_toolbar = pref.toolbar_color;
@@ -272,6 +274,7 @@ function initialize() {
 		let pending_dynamic = pref_dynamic;
 		let pending_no_theme_colour = pref_no_theme_colour;
 		let pending_overlay_opacity_factor = pref_overlay_opacity_factor;
+		let pending_overlay_opacity_threshold = pref_overlay_opacity_threshold;
 		let pending_tabbar = pref_tabbar;
 		let pending_tab_selected = pref_tab_selected;
 		let pending_toolbar = pref_toolbar;
@@ -290,8 +293,9 @@ function initialize() {
 		let pending_reservedColour_cs = pref_reservedColour_cs;
 		let pending_last_version = [2, 2];
 		// updates from v2.3 or earlier
-		if (pref_overlay_opacity_factor == null) {
-			pending_overlay_opacity_factor = 0.15;
+		if (pref_overlay_opacity_factor == null || pref_overlay_opacity_threshold == null) {
+			pending_overlay_opacity_factor = 0.25;
+			pending_overlay_opacity_threshold = 0.25;
 		}
 		// updates from v1.7.5 or earlier
 		if (pref_tab_selected == null || pref_toolbar_field == null || pref_toolbar_field_focus == null || pref_popup_border == null) {
@@ -385,6 +389,7 @@ function initialize() {
 				dynamic: pending_dynamic,
 				no_theme_color: pending_no_theme_colour,
 				overlay_opacity_factor: pending_overlay_opacity_factor,
+				overlay_opacity_threshold: pending_overlay_opacity_threshold,
 				tabbar_color: pending_tabbar,
 				tab_selected_color: pending_tab_selected,
 				toolbar_color: pending_toolbar,
@@ -695,7 +700,7 @@ function setFrameColour(windowId, colour, darkMode) {
 				// Compute the contrast between the colour and the base colour
 				let contrast = contrastFactor(colour, baseColour);
 				// Adjust the overlay opacity based on the contrast
-				colour.a = contrastAdjustedOverlayOpacity(contrast, pref_overlay_opacity_factor);
+				colour.a = contrastAdjustedOverlayOpacity(contrast, pref_overlay_opacity_factor, pref_overlay_opacity_threshold);
 				// Compute the overlay colour
 				let result = overlayColour(colour, baseColour);
 

--- a/background.js
+++ b/background.js
@@ -7,13 +7,14 @@ import {
 	reservedColour_aboutPage,
 	checkVersion,
 } from "./shared.js";
-import { rgba, dimColour } from "./colour.js";
+import { rgba, dimColour, contrastFactor, contrastAdjustedOverlayOpacity, overlayColour } from "./colour.js";
 
 // Settings cache: always synced with settings page (followed by handles in storage)
 var pref_scheme; // scheme
 var pref_allow_dark_light; // force
 var pref_dynamic; // dynamic
 var pref_no_theme_colour; // no_theme_color
+var pref_overlay_opacity_factor; // overlay_opacity_factor
 var pref_tabbar; // tabbar_color
 var pref_tab_selected; // tab_selected_color
 var pref_toolbar; // toolbar_color
@@ -48,6 +49,7 @@ function cachePref(pref) {
 	pref_allow_dark_light = pref.force;
 	pref_dynamic = pref.dynamic;
 	pref_no_theme_colour = pref.no_theme_color;
+	pref_overlay_opacity_factor = pref.overlay_opacity_factor;
 	pref_tabbar = pref.tabbar_color;
 	pref_tab_selected = pref.tab_selected_color;
 	pref_toolbar = pref.toolbar_color;
@@ -269,6 +271,7 @@ function initialize() {
 		let pending_force = pref_allow_dark_light;
 		let pending_dynamic = pref_dynamic;
 		let pending_no_theme_colour = pref_no_theme_colour;
+		let pending_overlay_opacity_factor = pref_overlay_opacity_factor;
 		let pending_tabbar = pref_tabbar;
 		let pending_tab_selected = pref_tab_selected;
 		let pending_toolbar = pref_toolbar;
@@ -286,6 +289,10 @@ function initialize() {
 		let pending_fallback_dark = pref_fallback_dark;
 		let pending_reservedColour_cs = pref_reservedColour_cs;
 		let pending_last_version = [2, 2];
+		// updates from v2.3 or earlier
+		if (pref_overlay_opacity_factor == null) {
+			pending_overlay_opacity_factor = 0.15;
+		}
 		// updates from v1.7.5 or earlier
 		if (pref_tab_selected == null || pref_toolbar_field == null || pref_toolbar_field_focus == null || pref_popup_border == null) {
 			pending_tab_selected = 0.1;
@@ -377,6 +384,7 @@ function initialize() {
 				force: pending_force,
 				dynamic: pending_dynamic,
 				no_theme_color: pending_no_theme_colour,
+				overlay_opacity_factor: pending_overlay_opacity_factor,
 				tabbar_color: pending_tabbar,
 				tab_selected_color: pending_tab_selected,
 				toolbar_color: pending_toolbar,
@@ -416,8 +424,7 @@ browser.runtime.onMessage.addListener((message, sender) => {
 			loadPrefAndUpdate();
 			break;
 		case "COLOUR_UPDATE":
-			let dark_mode = isDarkModeSuitable(message.colour);
-			sender.tab.active ? setFrameColour(sender.tab.windowId, message.colour, dark_mode) : update();
+			sender.tab.active ? setFrameColour(sender.tab.windowId, message.colour) : update();
 			break;
 		default:
 			break;
@@ -500,7 +507,7 @@ function updateEachWindow(tab) {
 				setFrameColour(windowId, "DEFAULT");
 			} else if (key.startsWith("Add-on ID: ") && current_reservedColour_cs[key]) {
 				let frameColour = rgba(current_reservedColour_cs[key]);
-				setFrameColour(windowId, frameColour, isDarkModeSuitable(frameColour));
+				setFrameColour(windowId, frameColour);
 			} else if (url.startsWith("moz-extension:")) {
 				setFrameColour(windowId, "ADDON");
 			} else {
@@ -683,12 +690,20 @@ function setFrameColour(windowId, colour, darkMode) {
 				(pref_allow_dark_light && current_scheme == "dark" && darkMode) ||
 				(pref_allow_dark_light && current_scheme == "light" && !darkMode)
 			) {
-				// Normal colouring
+				// Adaptive colouring based on contrast between the colour and the base colour
+				let baseColour = current_scheme == "dark" ? rgba(default_home_dark) : rgba(default_home_light);
+				// Compute the contrast between the colour and the base colour
+				let contrast = contrastFactor(colour, baseColour);
+				// Adjust the overlay opacity based on the contrast
+				colour.a = contrastAdjustedOverlayOpacity(contrast, pref_overlay_opacity_factor);
+				// Compute the overlay colour
+				let result = overlayColour(colour, baseColour);
+
 				if (darkMode) {
-					changeThemePara(colour, "dark");
+					changeThemePara(result, "dark");
 					applyTheme(windowId, adaptive_themes["dark"]);
 				} else {
-					changeThemePara(colour, "light");
+					changeThemePara(result, "light");
 					applyTheme(windowId, adaptive_themes["light"]);
 				}
 			} else if (!colour || pref_allow_dark_light) {
@@ -778,17 +793,6 @@ function applyTheme(windowId, theme) {
 	browser.runtime.sendMessage("OHTP@EasonWong", "TPOH_UPDATE").catch((e) => {
 		if (e.message != "Could not establish connection. Receiving end does not exist.") console.error(e);
 	});
-}
-
-/**
- * Returns if dark mode should be used considering the colour.
- * @param {object} colour The colour to check, in rgb object.
- * @returns {boolean} "true" => dark mode; "false" => light mode; "null" => both.
- */
-function isDarkModeSuitable(colour) {
-	if (colour == null || typeof colour != "object") return null;
-	let brightness = 0.299 * colour.r + 0.587 * colour.g + 0.114 * colour.b;
-	return brightness < 128; // For good contrast, colours' brightness should differ at least for 50%
 }
 
 /**

--- a/colour.js
+++ b/colour.js
@@ -67,8 +67,8 @@ export function contrastFactor(colour1, colour2) {
  * @param {number} overlayFactor Factor of the non-linear function. The higher the factor, the slower the opacity drops.
  * @returns Overlay opacity. 0 is fully transparent, 1 is fully opaque.
  */
-export function contrastAdjustedOverlayOpacity(contrast, overlayFactor = 0.15) {
-	return 1 - Math.pow(contrast, overlayFactor);
+export function contrastAdjustedOverlayOpacity(contrast, overlayFactor = 0.25, threshold = 0.25) {
+	return contrast <= threshold ? 1 : 1 - Math.pow(contrast, overlayFactor);
 }
 
 /**

--- a/colour.js
+++ b/colour.js
@@ -37,6 +37,41 @@ export function rgba(colour) {
 }
 
 /**
+ * Calculates the euclidean distance between colours adjusted for luminous efficacy. The result is then normalised to a range of 0-1. Represents how different the colours will appear to the human eye.
+ * @author bensaine on GitHub.
+ * @link https://en.wikipedia.org/wiki/Euclidean_distance
+ * @link https://en.wikipedia.org/wiki/Luminous_efficacy
+ * @link https://www.w3.org/TR/WCAG22/#dfn-relative-luminance
+ * @param {Object} colour1 First colour.
+ * @param {Object} colour2 Second colour.
+ * @returns Contrast factor. 0 is identical, 1 is maximally different.
+ */
+export function contrastFactor(colour1, colour2) {
+	// Note: the sRGB values are not linear, affecting the accuracy of the luminance calculation, but it is close enough for our purposes
+	// and less computationally expensive
+	// Compute delta for each channel
+	let r_delta = colour1.r - colour2.r;
+	let g_delta = colour1.g - colour2.g;
+	let b_delta = colour1.b - colour2.b;
+	// Compute the euclidean distance between the two colours adjusted for luminous efficacy
+	let distance = Math.sqrt(0.2126 * r_delta * r_delta + 0.7152 * g_delta * g_delta + 0.0722 * b_delta * b_delta);
+	// Normalise the distance to a range of 0-1
+	return distance/255;
+}
+
+/**
+ * Calculates the overlay opacity for a given contrast factor. The higher the contrast, the lower the opacity.
+ * This is a non-linear function that favours lower contrast values.
+ * @author bensaine on Github.
+ * @param {number} contrast Contrast factor. 0 is identical, 1 is maximally different.
+ * @param {number} overlayFactor Factor of the non-linear function. The higher the factor, the slower the opacity drops.
+ * @returns Overlay opacity. 0 is fully transparent, 1 is fully opaque.
+ */
+export function contrastAdjustedOverlayOpacity(contrast, overlayFactor = 0.15) {
+	return 1 - Math.pow(contrast, overlayFactor);
+}
+
+/**
  * Dims or lightens colour.
  * @param {object} colour Colour to process, in rgb object.
  * @param {number} dim between -1.0 (dim) to 1.0 (light).

--- a/options.html
+++ b/options.html
@@ -74,6 +74,13 @@
 					</h2>
 				</div>
 				<div id="tab_2" class="tab">
+					<div id="cus_overlay">
+						<h2 data-text="overlay">Overlay</h2>
+						<h3>
+							<label for="overlay_opacity_factor" class="TenEm" data-text="opacityFactor">Opacity factor</label>
+							<input type="range" id="overlay_opacity_factor" min="0" max="1" step="0.05" value="0.15" />
+						</h3>
+					</div>
 					<div id="cus_tabbar">
 						<h2 data-text="tabBar">Tab bar</h2>
 						<h3>

--- a/options.html
+++ b/options.html
@@ -78,7 +78,11 @@
 						<h2 data-text="overlay">Overlay</h2>
 						<h3>
 							<label for="overlay_opacity_factor" class="TenEm" data-text="opacityFactor">Opacity factor</label>
-							<input type="range" id="overlay_opacity_factor" min="0" max="1" step="0.05" value="0.15" />
+							<input type="range" id="overlay_opacity_factor" min="0" max="1" step="0.05" value="0.25" />
+						</h3>
+						<h3>
+							<label for="overlay_opacity_threshold" class="TenEm" data-text="opacityThreshold">Threshold</label>
+							<input type="range" id="overlay_opacity_threshold" min="0" max="1" step="0.05" value="0.25" />
 						</h3>
 					</div>
 					<div id="cus_tabbar">

--- a/options.js
+++ b/options.js
@@ -101,6 +101,7 @@ let force_mode_caption = document.getElementById("force_mode_caption");
 let dynamic = document.getElementById("dynamic");
 let no_theme_colour = document.getElementById("no_theme_color");
 let op_overlay_opacity_factor = document.getElementById("overlay_opacity_factor");
+let op_overlay_opacity_threshold = document.getElementById("overlay_opacity_threshold");
 let op_tabbar = document.getElementById("tabbar_color");
 let op_tab_selected = document.getElementById("tab_selected_color");
 let op_toolbar = document.getElementById("toolbar_color");
@@ -158,6 +159,7 @@ function load() {
 			if (!popupDetected()) {
 				// when the script is run by option page
 				op_overlay_opacity_factor.value = pref.overlay_opacity_factor;
+				op_overlay_opacity_threshold.value = pref.overlay_opacity_threshold;
 				op_tabbar.value = pref_tabbar;
 				op_tab_selected.value = pref_tab_selected;
 				op_toolbar.value = pref_toolbar;
@@ -309,6 +311,7 @@ if (popupDetected()) {
 	pp_more_custom.onclick = () => browser.runtime.openOptionsPage();
 } else {
 	op_overlay_opacity_factor.oninput = () => browser.storage.local.set({ overlay_opacity_factor: Number(op_overlay_opacity_factor.value) });
+	op_overlay_opacity_threshold.oninput = () => browser.storage.local.set({ overlay_opacity_threshold: Number(op_overlay_opacity_threshold.value) });
 	op_tabbar.oninput = () => browser.storage.local.set({ tabbar_color: Number(op_tabbar.value) });
 	op_tab_selected.oninput = () => browser.storage.local.set({ tab_selected_color: Number(op_tab_selected.value) });
 	op_toolbar.oninput = () => browser.storage.local.set({ toolbar_color: Number(op_toolbar.value) });

--- a/options.js
+++ b/options.js
@@ -100,6 +100,7 @@ let allow_dark_light = document.getElementById("force_mode");
 let force_mode_caption = document.getElementById("force_mode_caption");
 let dynamic = document.getElementById("dynamic");
 let no_theme_colour = document.getElementById("no_theme_color");
+let op_overlay_opacity_factor = document.getElementById("overlay_opacity_factor");
 let op_tabbar = document.getElementById("tabbar_color");
 let op_tab_selected = document.getElementById("tab_selected_color");
 let op_toolbar = document.getElementById("toolbar_color");
@@ -156,6 +157,7 @@ function load() {
 			no_theme_colour.checked = pref_no_theme_colour;
 			if (!popupDetected()) {
 				// when the script is run by option page
+				op_overlay_opacity_factor.value = pref.overlay_opacity_factor;
 				op_tabbar.value = pref_tabbar;
 				op_tab_selected.value = pref_tab_selected;
 				op_toolbar.value = pref_toolbar;
@@ -306,6 +308,7 @@ function addAction(i) {
 if (popupDetected()) {
 	pp_more_custom.onclick = () => browser.runtime.openOptionsPage();
 } else {
+	op_overlay_opacity_factor.oninput = () => browser.storage.local.set({ overlay_opacity_factor: Number(op_overlay_opacity_factor.value) });
 	op_tabbar.oninput = () => browser.storage.local.set({ tabbar_color: Number(op_tabbar.value) });
 	op_tab_selected.oninput = () => browser.storage.local.set({ tab_selected_color: Number(op_tab_selected.value) });
 	op_toolbar.oninput = () => browser.storage.local.set({ toolbar_color: Number(op_toolbar.value) });


### PR DESCRIPTION
Related to https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour/issues/74.

Makes it so colours "distant" (high contrast factor) from the base frame colour have a lesser impact on the frame colour.

i.e. Colours that are very bright or saturated will still give a slight overlay to the frame, but not to an overwhelming degree.

This PR adds a setting called "Overlay opacity factor" which controls how quickly the opacity drops in relation to the contrast factor [0-1]. This is the mathematical relation: `opacity = 1 - (contrast ^ (factor))`, where a factor of 1 is just the additive inverse of the contrast. See [graph](https://www.desmos.com/calculator/rszfkl5or8). The default is a factor of 0.15. This can be controlled if a user wants less or more overlay.

Before: 
<img width="1512" alt="image" src="https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour/assets/34781348/044c32e7-23d3-4d31-8147-fd616df1d27c">

After:
<img width="1510" alt="image" src="https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour/assets/34781348/54d43cfd-7e04-4d4a-8f4b-34d1a0465bab">

